### PR TITLE
Add TextMappingFormat

### DIFF
--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/BinaryMappingsReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/BinaryMappingsReader.java
@@ -28,6 +28,7 @@ package me.jamiemansfield.lorenz.io;
 import me.jamiemansfield.lorenz.io.kin.KinReader;
 
 import java.io.DataInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -40,7 +41,9 @@ import java.io.InputStream;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public abstract class BinaryMappingsReader extends MappingsReader<DataInputStream> {
+public abstract class BinaryMappingsReader extends MappingsReader {
+
+    protected final DataInputStream stream;
 
     /**
      * Creates a new mappings reader, for the given {@link InputStream}.
@@ -48,7 +51,12 @@ public abstract class BinaryMappingsReader extends MappingsReader<DataInputStrea
      * @param stream The input stream
      */
     protected BinaryMappingsReader(final InputStream stream) {
-        super(new DataInputStream(stream));
+        this.stream = new DataInputStream(stream);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.stream.close();
     }
 
 }

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/BinaryMappingsWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/BinaryMappingsWriter.java
@@ -28,6 +28,7 @@ package me.jamiemansfield.lorenz.io;
 import me.jamiemansfield.lorenz.io.kin.KinWriter;
 
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 
 /**
@@ -40,7 +41,9 @@ import java.io.OutputStream;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public abstract class BinaryMappingsWriter extends MappingsWriter<DataOutputStream> {
+public abstract class BinaryMappingsWriter extends MappingsWriter {
+
+    protected final DataOutputStream stream;
 
     /**
      * Creates a new mappings writer, from the given {@link OutputStream}.
@@ -48,7 +51,12 @@ public abstract class BinaryMappingsWriter extends MappingsWriter<DataOutputStre
      * @param stream The output stream, to write to
      */
     protected BinaryMappingsWriter(final OutputStream stream) {
-        super(new DataOutputStream(stream));
+        this.stream = new DataOutputStream(stream);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.stream.close();
     }
 
 }

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingFormat.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingFormat.java
@@ -54,6 +54,19 @@ public interface MappingFormat {
     MappingsReader createReader(final InputStream stream) throws IOException;
 
     /**
+     * Creates a {@link MappingsReader} for the given mappings file {@link Path}
+     * for the mapping format.
+     *
+     * @param path The path to the mappings file
+     * @return The mapping reader
+     * @throws IOException Should an I/O issue occur
+     * @throws UnsupportedOperationException If the format does not support reading
+     */
+    default MappingsReader createReader(final Path path) throws IOException {
+        return this.createReader(Files.newInputStream(path));
+    }
+
+    /**
      * Reads a mappings file into the given {@link MappingSet}.
      *
      * @param mappings The mapping set to read in to
@@ -62,7 +75,7 @@ public interface MappingFormat {
      * @throws IOException Should an I/O issue occur
      */
     default MappingSet read(final MappingSet mappings, final Path path) throws IOException {
-        try (final MappingsReader reader = this.createReader(Files.newInputStream(path))) {
+        try (final MappingsReader reader = this.createReader(path)) {
             reader.read(mappings);
         }
         return mappings;
@@ -86,9 +99,22 @@ public interface MappingFormat {
      * @param stream The output stream
      * @return The mapping writer
      * @throws IOException Should an I/O issue occur
-     * @throws UnsupportedOperationException If the format does not support reading
+     * @throws UnsupportedOperationException If the format does not support writing
      */
     MappingsWriter createWriter(final OutputStream stream) throws IOException;
+
+    /**
+     * Creates a {@link MappingsWriter} for the given mappings file {@link Path}
+     * for the mapping format.
+     *
+     * @param path The path to the mappings file
+     * @return The mapping writer
+     * @throws IOException Should an I/O issue occur
+     * @throws UnsupportedOperationException If the format does not support writing
+     */
+    default MappingsWriter createWriter(final Path path) throws IOException {
+        return this.createWriter(Files.newOutputStream(path));
+    }
 
     /**
      * Writes a mapping set to file.
@@ -98,7 +124,7 @@ public interface MappingFormat {
      * @throws IOException Should an I/O issue occur
      */
     default void write(final MappingSet mappings, final Path path) throws IOException {
-        try (final MappingsWriter writer = this.createWriter(Files.newOutputStream(path))) {
+        try (final MappingsWriter writer = this.createWriter(path)) {
             writer.write(mappings);
         }
     }

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingFormats.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingFormats.java
@@ -43,17 +43,17 @@ public final class MappingFormats {
     /**
      * The SRG mapping format.
      */
-    public static final MappingFormat SRG = new SrgMappingFormat();
+    public static final TextMappingFormat SRG = new SrgMappingFormat();
 
     /**
      * The CSRG (compact SRG) mapping format.
      */
-    public static final MappingFormat CSRG = new CSrgMappingFormat();
+    public static final TextMappingFormat CSRG = new CSrgMappingFormat();
 
     /**
      * The TSRG (tiny SRG) mapping format.
      */
-    public static final MappingFormat TSRG = new TSrgMappingFormat();
+    public static final TextMappingFormat TSRG = new TSrgMappingFormat();
 
     /**
      * The Kin (/k/ashike b/in/ary) mapping format.
@@ -63,12 +63,12 @@ public final class MappingFormats {
     /**
      * The JAM (Java Associated Mappings) mapping format.
      */
-    public static final MappingFormat JAM = new JamMappingFormat();
+    public static final TextMappingFormat JAM = new JamMappingFormat();
 
     /**
      * The Enigma mapping format.
      */
-    public static final MappingFormat ENIGMA = new EnigmaMappingFormat();
+    public static final TextMappingFormat ENIGMA = new EnigmaMappingFormat();
 
     private MappingFormats() {
     }

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingsReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingsReader.java
@@ -32,10 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Represents a reader that reads de-obfuscation mappings from a
- * given {@link InputStream}.
- *
- * @param <S> The type of the stream
+ * Represents a reader that reads de-obfuscation mappings.
  *
  * @see TextMappingsReader
  * @see BinaryMappingsReader
@@ -43,18 +40,7 @@ import java.io.InputStream;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public abstract class MappingsReader<S extends InputStream> implements Closeable {
-
-    protected final S stream;
-
-    /**
-     * Creates a new mappings reader, for the given {@link InputStream}.
-     *
-     * @param stream The input stream
-     */
-    protected MappingsReader(final S stream) {
-        this.stream = stream;
-    }
+public abstract class MappingsReader implements Closeable {
 
     /**
      * Reads mappings from the previously given {@link InputStream}, to
@@ -76,10 +62,5 @@ public abstract class MappingsReader<S extends InputStream> implements Closeable
      * @throws IOException Should an I/O issue occur
      */
     public abstract MappingSet read(final MappingSet mappings) throws IOException;
-
-    @Override
-    public void close() throws IOException {
-        this.stream.close();
-    }
 
 }

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingsWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/MappingsWriter.java
@@ -30,20 +30,16 @@ import me.jamiemansfield.lorenz.model.Mapping;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.stream.Collectors;
 
 /**
  * Represents a writer, that is capable of writing de-obfuscation
- * mappings to an {@link OutputStream}.
+ * mapping.
  *
  * Each mappings writer will be designed for a specific mapping
  * format, and intended to be used with try-for-resources.
- *
- * @param <S> The type of the stream
  *
  * @see TextMappingsWriter
  * @see BinaryMappingsWriter
@@ -51,7 +47,7 @@ import java.util.stream.Collectors;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public abstract class MappingsWriter<S extends OutputStream> implements Closeable {
+public abstract class MappingsWriter implements Closeable {
 
     /**
      * A {@link Comparator} used to alphabetise a collection of {@link Mapping}s.
@@ -83,28 +79,11 @@ public abstract class MappingsWriter<S extends OutputStream> implements Closeabl
                 .collect(Collectors.joining());
     }
 
-    protected final S stream;
-
     /**
-     * Creates a new mappings writer, from the given {@link OutputStream}.
-     *
-     * @param stream The output stream, to write to
-     */
-    protected MappingsWriter(final S stream) {
-        this.stream = stream;
-    }
-
-    /**
-     * Writes the given mappings to the previously given {@link PrintWriter}.
+     * Writes the given mappings to the previously given output.
      *
      * @param mappings The mapping set
      * @throws IOException Should an IO issue occur
      */
     public abstract void write(final MappingSet mappings) throws IOException;
-
-    @Override
-    public void close() throws IOException {
-        this.stream.close();
-    }
-
 }

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/TextMappingFormat.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/TextMappingFormat.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package me.jamiemansfield.lorenz.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A representation of a de-obfuscation mapping format serialized as text.
+ *
+ * @author Minecrell
+ * @since 0.4.0
+ */
+public interface TextMappingFormat extends MappingFormat {
+
+    /**
+     * Creates a {@link MappingsReader} from the given {@link Reader}
+     * for the mapping format.
+     *
+     * @param reader The reader
+     * @return The mapping reader
+     * @throws IOException Should an I/O issue occur
+     * @throws UnsupportedOperationException If the format does not support reading
+     */
+    MappingsReader createReader(final Reader reader) throws IOException;
+
+    @Override
+    default MappingsReader createReader(final InputStream stream) throws IOException {
+        return createReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+    }
+
+    @Override
+    default MappingsReader createReader(final Path path) throws IOException {
+        return createReader(Files.newBufferedReader(path));
+    }
+
+    /**
+     * Creates a {@link MappingsWriter} from the given {@link Writer}
+     * for the mapping format.
+     *
+     * @param writer The writer
+     * @return The mapping writer
+     * @throws IOException Should an I/O issue occur
+     * @throws UnsupportedOperationException If the format does not support writing
+     */
+    MappingsWriter createWriter(final Writer writer) throws IOException;
+
+    @Override
+    default MappingsWriter createWriter(final OutputStream stream) throws IOException {
+        return createWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8));
+    }
+
+    @Override
+    default MappingsWriter createWriter(final Path path) throws IOException {
+        return createWriter(Files.newBufferedWriter(path));
+    }
+
+}

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/TextMappingsReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/TextMappingsReader.java
@@ -34,8 +34,7 @@ import me.jamiemansfield.lorenz.io.srg.tsrg.TSrgReader;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -60,14 +59,13 @@ public abstract class TextMappingsReader extends MappingsReader {
     protected final Function<MappingSet, Processor> processor;
 
     /**
-     * Creates a new mappings reader, for the given {@link InputStream}.
+     * Creates a new mappings reader, for the given {@link Reader}.
      *
-     * @param stream The input stream
+     * @param reader The reader
      * @param processor The line processor to use for reading the lines
      */
-    protected TextMappingsReader(final InputStream stream, final Function<MappingSet, Processor> processor) {
-        super(stream);
-        this.reader = new BufferedReader(new InputStreamReader(stream));
+    protected TextMappingsReader(Reader reader, final Function<MappingSet, Processor> processor) {
+        this.reader = reader instanceof BufferedReader ? (BufferedReader) reader : new BufferedReader(reader);
         this.processor = processor;
     }
 

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/TextMappingsWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/TextMappingsWriter.java
@@ -31,8 +31,10 @@ import me.jamiemansfield.lorenz.io.srg.csrg.CSrgWriter;
 import me.jamiemansfield.lorenz.io.srg.SrgWriter;
 import me.jamiemansfield.lorenz.io.srg.tsrg.TSrgWriter;
 
-import java.io.OutputStream;
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Writer;
 
 /**
  * An implementation of {@link MappingsWriter} designed to aid
@@ -53,17 +55,21 @@ public abstract class TextMappingsWriter extends MappingsWriter {
     protected final PrintWriter writer;
 
     /**
-     * Creates a new mappings writer, from the given {@link OutputStream}.
+     * Creates a new mappings writer, from the given {@link Writer}.
      *
-     * @param stream The output stream, to write to
+     * @param writer The output writer, to write to
      */
-    protected TextMappingsWriter(final OutputStream stream) {
-        super(stream);
-        this.writer = new PrintWriter(stream);
+    protected TextMappingsWriter(final Writer writer) {
+        if (writer instanceof PrintWriter) {
+            this.writer = (PrintWriter) writer;
+        } else {
+            BufferedWriter bufferedWriter = writer instanceof BufferedWriter ? (BufferedWriter) writer : new BufferedWriter(writer);
+            this.writer = new PrintWriter(bufferedWriter);
+        }
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
         this.writer.close();
     }
 

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/enigma/EnigmaMappingFormat.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/enigma/EnigmaMappingFormat.java
@@ -25,16 +25,12 @@
 
 package me.jamiemansfield.lorenz.io.enigma;
 
-import me.jamiemansfield.lorenz.io.MappingFormat;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.MappingsWriter;
-import me.jamiemansfield.lorenz.io.jam.JamConstants;
-import me.jamiemansfield.lorenz.io.jam.JamReader;
-import me.jamiemansfield.lorenz.io.jam.JamWriter;
+import me.jamiemansfield.lorenz.io.TextMappingFormat;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.Optional;
 
 /**
@@ -43,16 +39,16 @@ import java.util.Optional;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public class EnigmaMappingFormat implements MappingFormat {
+public class EnigmaMappingFormat implements TextMappingFormat {
 
     @Override
-    public MappingsReader createReader(final InputStream stream) throws IOException {
-        return new EnigmaReader(stream);
+    public MappingsReader createReader(final Reader reader) {
+        return new EnigmaReader(reader);
     }
 
     @Override
-    public MappingsWriter createWriter(final OutputStream stream) throws IOException {
-        return new EnigmaWriter(stream);
+    public MappingsWriter createWriter(final Writer writer) {
+        return new EnigmaWriter(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/enigma/EnigmaReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/enigma/EnigmaReader.java
@@ -36,7 +36,7 @@ import me.jamiemansfield.lorenz.io.TextMappingsReader;
 import me.jamiemansfield.lorenz.model.ClassMapping;
 import me.jamiemansfield.lorenz.model.MethodMapping;
 
-import java.io.InputStream;
+import java.io.Reader;
 import java.util.Stack;
 import java.util.stream.Collectors;
 
@@ -48,8 +48,8 @@ import java.util.stream.Collectors;
  */
 public class EnigmaReader extends TextMappingsReader {
 
-    public EnigmaReader(final InputStream stream) {
-        super(stream, Processor::new);
+    public EnigmaReader(final Reader reader) {
+        super(reader, Processor::new);
     }
 
     public static class Processor extends TextMappingsReader.Processor {

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/enigma/EnigmaWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/enigma/EnigmaWriter.java
@@ -41,7 +41,7 @@ import me.jamiemansfield.lorenz.model.MethodMapping;
 import me.jamiemansfield.lorenz.model.MethodParameterMapping;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.Writer;
 import java.util.Optional;
 
 /**
@@ -87,8 +87,8 @@ public class EnigmaWriter extends TextMappingsWriter {
         return typeBuilder.toString();
     }
 
-    public EnigmaWriter(final OutputStream stream) {
-        super(stream);
+    public EnigmaWriter(final Writer writer) {
+        super(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/jam/JamMappingFormat.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/jam/JamMappingFormat.java
@@ -25,16 +25,12 @@
 
 package me.jamiemansfield.lorenz.io.jam;
 
-import me.jamiemansfield.lorenz.io.MappingFormat;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.MappingsWriter;
-import me.jamiemansfield.lorenz.io.srg.SrgConstants;
-import me.jamiemansfield.lorenz.io.srg.SrgReader;
-import me.jamiemansfield.lorenz.io.srg.SrgWriter;
+import me.jamiemansfield.lorenz.io.TextMappingFormat;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.Optional;
 
 /**
@@ -43,16 +39,16 @@ import java.util.Optional;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public class JamMappingFormat implements MappingFormat {
+public class JamMappingFormat implements TextMappingFormat {
 
     @Override
-    public MappingsReader createReader(final InputStream stream) throws IOException {
-        return new JamReader(stream);
+    public MappingsReader createReader(final Reader reader) {
+        return new JamReader(reader);
     }
 
     @Override
-    public MappingsWriter createWriter(final OutputStream stream) throws IOException {
-        return new JamWriter(stream);
+    public MappingsWriter createWriter(final Writer writer) {
+        return new JamWriter(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/jam/JamReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/jam/JamReader.java
@@ -29,8 +29,7 @@ import me.jamiemansfield.lorenz.MappingSet;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.TextMappingsReader;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
 
 /**
  * An implementation of {@link MappingsReader} for the JAM format.
@@ -40,8 +39,8 @@ import java.io.InputStream;
  */
 public class JamReader extends TextMappingsReader {
 
-    public JamReader(final InputStream stream) {
-        super(stream, Processor::new);
+    public JamReader(final Reader reader) {
+        super(reader, Processor::new);
     }
 
     public static class Processor extends TextMappingsReader.Processor {

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/jam/JamWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/jam/JamWriter.java
@@ -35,7 +35,7 @@ import me.jamiemansfield.lorenz.model.Mapping;
 import me.jamiemansfield.lorenz.model.MethodMapping;
 import me.jamiemansfield.lorenz.model.MethodParameterMapping;
 
-import java.io.OutputStream;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -52,8 +52,8 @@ public class JamWriter extends TextMappingsWriter {
     private final List<String> fields = new ArrayList<>();
     private final List<String> methods = new ArrayList<>();
 
-    public JamWriter(final OutputStream stream) {
-        super(stream);
+    public JamWriter(final Writer writer) {
+        super(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/SrgMappingFormat.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/SrgMappingFormat.java
@@ -25,13 +25,12 @@
 
 package me.jamiemansfield.lorenz.io.srg;
 
-import me.jamiemansfield.lorenz.io.MappingFormat;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.MappingsWriter;
+import me.jamiemansfield.lorenz.io.TextMappingFormat;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.Optional;
 
 /**
@@ -40,16 +39,16 @@ import java.util.Optional;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public class SrgMappingFormat implements MappingFormat {
+public class SrgMappingFormat implements TextMappingFormat {
 
     @Override
-    public MappingsReader createReader(final InputStream stream) throws IOException {
-        return new SrgReader(stream);
+    public MappingsReader createReader(final Reader reader) {
+        return new SrgReader(reader);
     }
 
     @Override
-    public MappingsWriter createWriter(final OutputStream stream) throws IOException {
-        return new SrgWriter(stream);
+    public MappingsWriter createWriter(final Writer writer) {
+        return new SrgWriter(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/SrgReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/SrgReader.java
@@ -29,8 +29,7 @@ import me.jamiemansfield.lorenz.MappingSet;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.TextMappingsReader;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
 
 /**
  * An implementation of {@link MappingsReader} for the SRG format.
@@ -41,12 +40,12 @@ import java.io.InputStream;
 public class SrgReader extends TextMappingsReader {
 
     /**
-     * Creates a new SRG mappings reader, for the given {@link InputStream}.
+     * Creates a new SRG mappings reader, for the given {@link Reader}.
      *
-     * @param stream The input stream
+     * @param reader The reader
      */
-    public SrgReader(final InputStream stream) {
-        super(stream, SrgReader.Processor::new);
+    public SrgReader(final Reader reader) {
+        super(reader, SrgReader.Processor::new);
     }
 
     /**

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/SrgWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/SrgWriter.java
@@ -33,7 +33,7 @@ import me.jamiemansfield.lorenz.model.FieldMapping;
 import me.jamiemansfield.lorenz.model.Mapping;
 import me.jamiemansfield.lorenz.model.MethodMapping;
 
-import java.io.OutputStream;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,12 +50,12 @@ public class SrgWriter extends TextMappingsWriter {
     private final List<String> methods = new ArrayList<>();
 
     /**
-     * Creates a new SRG mappings writer, from the given {@link OutputStream}.
+     * Creates a new SRG mappings writer, from the given {@link Writer}.
      *
-     * @param stream The output stream, to write to
+     * @param writer The writer
      */
-    public SrgWriter(final OutputStream stream) {
-        super(stream);
+    public SrgWriter(final Writer writer) {
+        super(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/csrg/CSrgMappingFormat.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/csrg/CSrgMappingFormat.java
@@ -25,14 +25,13 @@
 
 package me.jamiemansfield.lorenz.io.srg.csrg;
 
-import me.jamiemansfield.lorenz.io.MappingFormat;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.MappingsWriter;
+import me.jamiemansfield.lorenz.io.TextMappingFormat;
 import me.jamiemansfield.lorenz.io.srg.SrgConstants;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.Optional;
 
 /**
@@ -41,16 +40,16 @@ import java.util.Optional;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public class CSrgMappingFormat implements MappingFormat {
+public class CSrgMappingFormat implements TextMappingFormat {
 
     @Override
-    public MappingsReader createReader(final InputStream stream) throws IOException {
-        return new CSrgReader(stream);
+    public MappingsReader createReader(final Reader reader) {
+        return new CSrgReader(reader);
     }
 
     @Override
-    public MappingsWriter createWriter(final OutputStream stream) throws IOException {
-        return new CSrgWriter(stream);
+    public MappingsWriter createWriter(final Writer writer) {
+        return new CSrgWriter(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/csrg/CSrgReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/csrg/CSrgReader.java
@@ -30,8 +30,7 @@ import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.TextMappingsReader;
 import me.jamiemansfield.lorenz.io.srg.SrgConstants;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
 
 /**
  * An implementation of {@link MappingsReader} for the CSRG format.
@@ -42,12 +41,12 @@ import java.io.InputStream;
 public class CSrgReader extends TextMappingsReader {
 
     /**
-     * Creates a new CSRG mappings reader, for the given {@link InputStream}.
+     * Creates a new CSRG mappings reader, for the given {@link Reader}.
      *
-     * @param stream The input stream
+     * @param reader The reader
      */
-    public CSrgReader(final InputStream stream) {
-        super(stream, Processor::new);
+    public CSrgReader(final Reader reader) {
+        super(reader, Processor::new);
     }
 
     /**

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/csrg/CSrgWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/csrg/CSrgWriter.java
@@ -33,7 +33,7 @@ import me.jamiemansfield.lorenz.model.FieldMapping;
 import me.jamiemansfield.lorenz.model.Mapping;
 import me.jamiemansfield.lorenz.model.MethodMapping;
 
-import java.io.OutputStream;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,12 +50,12 @@ public class CSrgWriter extends TextMappingsWriter {
     private final List<String> methods = new ArrayList<>();
 
     /**
-     * Creates a new CSRG mappings writer, from the given {@link OutputStream}.
+     * Creates a new CSRG mappings writer, from the given {@link Writer}.
      *
-     * @param stream The output stream, to write to
+     * @param writer The writer
      */
-    public CSrgWriter(final OutputStream stream) {
-        super(stream);
+    public CSrgWriter(final Writer writer) {
+        super(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/tsrg/TSrgMappingFormat.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/tsrg/TSrgMappingFormat.java
@@ -28,11 +28,14 @@ package me.jamiemansfield.lorenz.io.srg.tsrg;
 import me.jamiemansfield.lorenz.io.MappingFormat;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.MappingsWriter;
+import me.jamiemansfield.lorenz.io.TextMappingFormat;
 import me.jamiemansfield.lorenz.io.srg.SrgConstants;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.Optional;
 
 /**
@@ -41,16 +44,16 @@ import java.util.Optional;
  * @author Jamie Mansfield
  * @since 0.4.0
  */
-public class TSrgMappingFormat implements MappingFormat {
+public class TSrgMappingFormat implements TextMappingFormat {
 
     @Override
-    public MappingsReader createReader(final InputStream stream) throws IOException {
-        return new TSrgReader(stream);
+    public MappingsReader createReader(final Reader reader) {
+        return new TSrgReader(reader);
     }
 
     @Override
-    public MappingsWriter createWriter(final OutputStream stream) throws IOException {
-        return new TSrgWriter(stream);
+    public MappingsWriter createWriter(final Writer writer) {
+        return new TSrgWriter(writer);
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/tsrg/TSrgReader.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/tsrg/TSrgReader.java
@@ -31,8 +31,7 @@ import me.jamiemansfield.lorenz.io.TextMappingsReader;
 import me.jamiemansfield.lorenz.io.srg.SrgConstants;
 import me.jamiemansfield.lorenz.model.ClassMapping;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
 
 /**
  * An implementation of {@link MappingsReader} for the TSRG format.
@@ -43,12 +42,12 @@ import java.io.InputStream;
 public class TSrgReader extends TextMappingsReader {
 
     /**
-     * Creates a new TSRG mappings reader, for the given {@link InputStream}.
+     * Creates a new TSRG mappings reader, for the given {@link Reader}.
      *
-     * @param stream The input stream
+     * @param reader The reader
      */
-    public TSrgReader(final InputStream stream) {
-        super(stream, TSrgReader.Processor::new);
+    public TSrgReader(final Reader reader) {
+        super(reader, TSrgReader.Processor::new);
     }
 
     /**

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/tsrg/TSrgWriter.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/io/srg/tsrg/TSrgWriter.java
@@ -33,7 +33,7 @@ import me.jamiemansfield.lorenz.model.FieldMapping;
 import me.jamiemansfield.lorenz.model.Mapping;
 import me.jamiemansfield.lorenz.model.MethodMapping;
 
-import java.io.OutputStream;
+import java.io.Writer;
 
 /**
  * An implementation of {@link MappingsWriter} for the TSRG format.
@@ -44,12 +44,12 @@ import java.io.OutputStream;
 public class TSrgWriter extends TextMappingsWriter {
 
     /**
-     * Creates a new TSRG mappings writer, from the given {@link OutputStream}.
+     * Creates a new TSRG mappings writer, from the given {@link Writer}.
      *
-     * @param stream The output stream, to write to
+     * @param writer The writer
      */
-    public TSrgWriter(final OutputStream stream) {
-        super(stream);
+    public TSrgWriter(final Writer writer) {
+        super(writer);
     }
 
     @Override

--- a/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/enigma/EnigmaReaderTest.java
+++ b/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/enigma/EnigmaReaderTest.java
@@ -33,9 +33,9 @@ import me.jamiemansfield.bombe.type.MethodDescriptor;
 import me.jamiemansfield.bombe.type.signature.FieldSignature;
 import me.jamiemansfield.bombe.type.signature.MethodSignature;
 import me.jamiemansfield.lorenz.MappingSet;
+import me.jamiemansfield.lorenz.io.MappingFormats;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.enigma.EnigmaConstants;
-import me.jamiemansfield.lorenz.io.enigma.EnigmaReader;
 import me.jamiemansfield.lorenz.model.FieldMapping;
 import me.jamiemansfield.lorenz.model.InnerClassMapping;
 import me.jamiemansfield.lorenz.model.MethodMapping;
@@ -50,9 +50,9 @@ public class EnigmaReaderTest {
     private final MappingSet mappings;
 
     public EnigmaReaderTest() throws IOException {
-        final MappingsReader reader = new EnigmaReader(EnigmaReaderTest.class.getResourceAsStream("/test.enigma"));
-        this.mappings = reader.read();
-        reader.close();
+        try (MappingsReader reader = MappingFormats.ENIGMA.createReader(EnigmaReaderTest.class.getResourceAsStream("/test.enigma"))) {
+            this.mappings = reader.read();
+        }
     }
 
     @Test

--- a/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/jam/JamReaderTest.java
+++ b/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/jam/JamReaderTest.java
@@ -33,9 +33,9 @@ import me.jamiemansfield.bombe.type.MethodDescriptor;
 import me.jamiemansfield.bombe.type.signature.FieldSignature;
 import me.jamiemansfield.bombe.type.signature.MethodSignature;
 import me.jamiemansfield.lorenz.MappingSet;
+import me.jamiemansfield.lorenz.io.MappingFormats;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.jam.JamConstants;
-import me.jamiemansfield.lorenz.io.jam.JamReader;
 import me.jamiemansfield.lorenz.model.FieldMapping;
 import me.jamiemansfield.lorenz.model.InnerClassMapping;
 import me.jamiemansfield.lorenz.model.MethodMapping;
@@ -50,9 +50,9 @@ public class JamReaderTest {
     private final MappingSet mappings;
 
     public JamReaderTest() throws IOException {
-        final MappingsReader reader = new JamReader(JamReaderTest.class.getResourceAsStream("/test.jam"));
-        this.mappings = reader.read();
-        reader.close();
+        try (MappingsReader reader = MappingFormats.JAM.createReader(JamReaderTest.class.getResourceAsStream("/test.jam"))) {
+            this.mappings = reader.read();
+        }
     }
 
     @Test

--- a/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/AbstractSrgReaderTest.java
+++ b/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/AbstractSrgReaderTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import me.jamiemansfield.bombe.type.MethodDescriptor;
 import me.jamiemansfield.bombe.type.signature.MethodSignature;
 import me.jamiemansfield.lorenz.MappingSet;
+import me.jamiemansfield.lorenz.io.MappingFormat;
 import me.jamiemansfield.lorenz.io.MappingsReader;
 import me.jamiemansfield.lorenz.io.srg.SrgConstants;
 import me.jamiemansfield.lorenz.model.FieldMapping;
@@ -41,17 +42,15 @@ import me.jamiemansfield.lorenz.model.TopLevelClassMapping;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.Callable;
-
 @Disabled
 public abstract class AbstractSrgReaderTest {
 
     private final MappingSet mappings;
 
-    protected AbstractSrgReaderTest(final Callable<MappingsReader> readerFunction) throws Exception {
-        final MappingsReader reader = readerFunction.call();
-        this.mappings = reader.read();
-        reader.close();
+    protected AbstractSrgReaderTest(final MappingFormat format, String path) throws Exception {
+        try (MappingsReader reader = format.createReader(getClass().getResourceAsStream(path))) {
+            this.mappings = reader.read();
+        }
     }
 
     @Test

--- a/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/CSrgReaderTest.java
+++ b/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/CSrgReaderTest.java
@@ -27,6 +27,7 @@ package me.jamiemansfield.lorenz.test.io.srg;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import me.jamiemansfield.lorenz.io.MappingFormats;
 import me.jamiemansfield.lorenz.io.srg.csrg.CSrgReader;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +36,7 @@ import java.io.IOException;
 public class CSrgReaderTest extends AbstractSrgReaderTest {
 
     public CSrgReaderTest() throws Exception {
-        super(() -> new CSrgReader(CSrgReaderTest.class.getResourceAsStream("/test.csrg")));
+        super(MappingFormats.CSRG, "/test.csrg");
     }
 
     @Test

--- a/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/SrgReaderTest.java
+++ b/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/SrgReaderTest.java
@@ -27,6 +27,7 @@ package me.jamiemansfield.lorenz.test.io.srg;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import me.jamiemansfield.lorenz.io.MappingFormats;
 import me.jamiemansfield.lorenz.io.srg.SrgReader;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +36,7 @@ import java.io.IOException;
 public class SrgReaderTest extends AbstractSrgReaderTest {
 
     public SrgReaderTest() throws Exception {
-        super(() -> new SrgReader(SrgReaderTest.class.getResourceAsStream("/test.srg")));
+        super(MappingFormats.SRG, "/test.srg");
     }
 
     @Test

--- a/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/TSrgReaderTest.java
+++ b/lorenz/src/test/java/me/jamiemansfield/lorenz/test/io/srg/TSrgReaderTest.java
@@ -27,6 +27,7 @@ package me.jamiemansfield.lorenz.test.io.srg;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import me.jamiemansfield.lorenz.io.MappingFormats;
 import me.jamiemansfield.lorenz.io.srg.tsrg.TSrgReader;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +36,7 @@ import java.io.IOException;
 public class TSrgReaderTest extends AbstractSrgReaderTest {
 
     public TSrgReaderTest() throws Exception {
-        super(() -> new TSrgReader(TSrgReaderTest.class.getResourceAsStream("/test.tsrg")));
+        super(MappingFormats.TSRG, "/test.tsrg");
     }
 
     @Test


### PR DESCRIPTION
Extends MappingFormat and allows reading text mapping formats from readers/writers instead of just binary input/output streams.