### PR TITLE
Add getSimple(De)ObfuscatedName

### DIFF
--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/model/Mapping.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/model/Mapping.java
@@ -62,6 +62,24 @@ public interface Mapping<M extends Mapping> {
     M setDeobfuscatedName(final String deobfuscatedName);
 
     /**
+     * Gets the unqualified ("simple") obfuscated name of the member.
+     *
+     * @return The simple obfuscated name
+     */
+    default String getSimpleObfuscatedName() {
+        return getObfuscatedName();
+    }
+
+    /**
+     * Gets the unqualified ("simple") deobfuscated name of the member.
+     *
+     * @return The simple deobfuscated name
+     */
+    default String getSimpleDeobfuscatedName() {
+        return getDeobfuscatedName();
+    }
+
+    /**
      * Gets the fully-qualified obfuscated name of the member.
      *
      * @return The fully-qualified obfuscated name

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/model/TopLevelClassMapping.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/model/TopLevelClassMapping.java
@@ -34,6 +34,20 @@ package me.jamiemansfield.lorenz.model;
 public interface TopLevelClassMapping extends ClassMapping<TopLevelClassMapping> {
 
     @Override
+    default String getSimpleObfuscatedName() {
+        String name = this.getObfuscatedName();
+        int classIndex = name.lastIndexOf('/');
+        return classIndex >= 0 ? name.substring(classIndex + 1) : name;
+    }
+
+    @Override
+    default String getSimpleDeobfuscatedName() {
+        String name = this.getDeobfuscatedName();
+        int classIndex = name.lastIndexOf('/');
+        return classIndex >= 0 ? name.substring(classIndex + 1) : name;
+    }
+
+    @Override
     default String getFullObfuscatedName() {
         return this.getObfuscatedName();
     }


### PR DESCRIPTION
This is essentially the opposite of `getFull(De)ObfuscatedName()`: it always returns the unqualified ("simple") name of the mapping.

I'm open for better naming suggestions :)