### PR TITLE
Minor cleanup and optimizations

### DIFF
--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/InnerClassMappingImpl.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/InnerClassMappingImpl.java
@@ -59,12 +59,12 @@ public class InnerClassMappingImpl extends AbstractClassMappingImpl<InnerClassMa
 
     @Override
     public InnerClassMapping setDeobfuscatedName(final String deobfuscatedName) {
-        if (!deobfuscatedName.contains("$")) {
+        final int lastIndex = deobfuscatedName.lastIndexOf('$');
+        if (lastIndex == -1) {
             return super.setDeobfuscatedName(deobfuscatedName);
         }
 
         // Split the obfuscated name, to fetch the parent class name, and inner class name
-        final int lastIndex = deobfuscatedName.lastIndexOf('$');
         final String innerClassName = deobfuscatedName.substring(lastIndex + 1);
 
         // Set the correct class name!

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/MethodParameterMappingImpl.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/MethodParameterMappingImpl.java
@@ -48,7 +48,7 @@ public class MethodParameterMappingImpl
      * @param deobfuscatedName The de-obfuscated name
      */
     public MethodParameterMappingImpl(final MethodMapping parent, final int index, String deobfuscatedName) {
-        super(parent, "" + index, deobfuscatedName);
+        super(parent, String.valueOf(index), deobfuscatedName);
         this.index = index;
     }
 

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/model/MethodMapping.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/model/MethodMapping.java
@@ -119,7 +119,7 @@ public interface MethodMapping extends MemberMapping<MethodMapping, ClassMapping
      */
     default MethodParameterMapping getOrCreateParameterMapping(final int index) {
         return this.getParameterMapping(index)
-                .orElseGet(() -> this.createParameterMapping(index, "" + index));
+                .orElseGet(() -> this.createParameterMapping(index, String.valueOf(index)));
     }
 
     /**

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/model/MethodParameterMapping.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/model/MethodParameterMapping.java
@@ -43,7 +43,7 @@ public interface MethodParameterMapping extends MemberMapping<MethodParameterMap
 
     @Override
     default String getObfuscatedName() {
-        return "" + this.getIndex();
+        return String.valueOf(this.getIndex());
     }
 
 }


### PR DESCRIPTION
These are just a few things I've noticed while reading through the code.

`getClassMapping` -> `Optional<? extends ClassMapping<?>>`:
Right now it unpacks the `Optional`s, just to pack them in another one, with the more generic type. IMO `Optional`s and Java's Generics are annoying, but the way to avoid that is to return an `Optional` with `? extends`. Alternatively some hacky casting could be used here.

`"" + char` -> `String.valueOf(char)`: see https://stackoverflow.com/a/8172439