### PR TITLE
Automatically normalize top level class names

### DIFF
--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/MappingSetImpl.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/MappingSetImpl.java
@@ -68,20 +68,20 @@ public class MappingSetImpl implements MappingSet {
 
     @Override
     public TopLevelClassMapping createTopLevelClassMapping(final String obfuscatedName, final String deobfuscatedName) {
-        return this.topLevelClasses.compute(obfuscatedName, (name, existingMapping) -> {
+        return this.topLevelClasses.compute(obfuscatedName.replace('.', '/'), (name, existingMapping) -> {
             if (existingMapping != null) return existingMapping.setDeobfuscatedName(deobfuscatedName);
-            return this.getModelFactory().createTopLevelClassMapping(this, obfuscatedName, deobfuscatedName);
+            return this.getModelFactory().createTopLevelClassMapping(this, name, deobfuscatedName);
         });
     }
 
     @Override
     public Optional<TopLevelClassMapping> getTopLevelClassMapping(final String obfuscatedName) {
-        return Optional.ofNullable(this.topLevelClasses.get(obfuscatedName));
+        return Optional.ofNullable(this.topLevelClasses.get(obfuscatedName.replace('.', '/')));
     }
 
     @Override
     public boolean hasTopLevelClassMapping(final String obfuscatedName) {
-        return this.topLevelClasses.containsKey(obfuscatedName);
+        return this.topLevelClasses.containsKey(obfuscatedName.replace('.', '/'));
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/TopLevelClassMappingImpl.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/TopLevelClassMappingImpl.java
@@ -46,7 +46,12 @@ public class TopLevelClassMappingImpl
      * @param deobfuscatedName The de-obfuscated name
      */
     public TopLevelClassMappingImpl(final MappingSet mappings, final String obfuscatedName, final String deobfuscatedName) {
-        super(mappings, obfuscatedName, deobfuscatedName);
+        super(mappings, obfuscatedName.replace('.', '/'), deobfuscatedName.replace('.', '/'));
+    }
+
+    @Override
+    public TopLevelClassMapping setDeobfuscatedName(String deobfuscatedName) {
+        return super.setDeobfuscatedName(deobfuscatedName.replace('.', '/'));
     }
 
     @Override


### PR DESCRIPTION
This is already done in Bombe's `ObjectType`, so it would be nice to automatically handle this here too.