### PR TITLE
Fix simple name getters for anonymous/local classes

### DIFF
--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/InnerClassMappingImpl.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/InnerClassMappingImpl.java
@@ -58,6 +58,29 @@ public class InnerClassMappingImpl extends AbstractClassMappingImpl<InnerClassMa
     }
 
     @Override
+    public String getSimpleObfuscatedName() {
+        return stripAsciiDigits(getObfuscatedName());
+    }
+
+    @Override
+    public String getSimpleDeobfuscatedName() {
+        return stripAsciiDigits(getDeobfuscatedName());
+    }
+
+    private static String stripAsciiDigits(String name) {
+        for (int pos = 0; pos < name.length(); pos++) {
+            if (!isAsciiDigit(name.charAt(pos))) {
+                return name.substring(pos);
+            }
+        }
+        return "";
+    }
+
+    private static boolean isAsciiDigit(char c) {
+        return '0' <= c && c <= '9';
+    }
+
+    @Override
     public InnerClassMapping setDeobfuscatedName(final String deobfuscatedName) {
         final int lastIndex = deobfuscatedName.lastIndexOf('$');
         if (lastIndex == -1) {

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/model/ClassMapping.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/model/ClassMapping.java
@@ -43,6 +43,22 @@ import java.util.Optional;
 public interface ClassMapping<M extends ClassMapping> extends Mapping<M> {
 
     /**
+     * {@inheritDoc}
+     * @see Class#getSimpleName()
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se10/html/jls-13.html#jls-13.1">Specification</a>
+     */
+    @Override
+    String getSimpleObfuscatedName();
+
+    /**
+     * {@inheritDoc}
+     * @see Class#getSimpleName()
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se10/html/jls-13.html#jls-13.1">Specification</a>
+     */
+    @Override
+    String getSimpleDeobfuscatedName();
+
+    /**
      * Gets an immutable collection of all of the field mappings
      * of the class mapping.
      *

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/model/InnerClassMapping.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/model/InnerClassMapping.java
@@ -45,6 +45,24 @@ public interface InnerClassMapping extends ClassMapping<InnerClassMapping>, Memb
     @Override
     InnerClassMapping setDeobfuscatedName(final String deobfuscatedName);
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p><strong>Note:</strong> The simple name is empty for anonymous classes.
+     * For local classes, the leading digits are stripped.</p>
+     */
+    @Override
+    String getSimpleObfuscatedName();
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p><strong>Note:</strong> The simple name is empty for anonymous classes.
+     * For local classes, the leading digits are stripped.</p>
+     */
+    @Override
+    String getSimpleDeobfuscatedName();
+
     @Override
     default String getFullObfuscatedName() {
         return String.format("%s$%s", this.getParent().getFullObfuscatedName(), this.getObfuscatedName());


### PR DESCRIPTION
Align `ClassMapping.getSimple(De)ObfuscatedName()` with `Class.getSimpleName()` and return an empty string for anonymous, and the leading digits stripped for local classes. The digits are not part of the simple name.

E.g. in the Java Language Specification: https://docs.oracle.com/javase/specs/jls/se10/html/jls-13.html#jls-13.1

> The binary name of a local class (§14.3) consists of the binary name of its immediately enclosing type, followed by $, **followed by a non-empty sequence of digits, followed by the simple name of the local class.**