### PR TITLE
Add computeClassMapping and computeFieldMapping

### DIFF
--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/MappingSet.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/MappingSet.java
@@ -149,6 +149,33 @@ public interface MappingSet {
     }
 
     /**
+     * Attempts to locate a class mapping for the given obfuscated name.
+     *
+     * <p>This is equivalent to calling {@link #getClassMapping(String)},
+     * except that it will insert a new inner class mapping in case a
+     * class mapping for the outer class exists.</p>
+     *
+     * <p>This method exists to simplify remapping, where it is important
+     * to keep inner classes a part of the outer class.</p>
+     *
+     * @param obfuscatedName The obfuscated name
+     * @return The class mapping, wrapped in an {@link Optional}
+     */
+    default Optional<? extends ClassMapping<?>> computeClassMapping(final String obfuscatedName) {
+        final int lastIndex = obfuscatedName.lastIndexOf('$');
+        if (lastIndex == -1) return this.getTopLevelClassMapping(obfuscatedName);
+
+        // Split the obfuscated name, to fetch the parent class name, and inner class name
+        final String parentClassName = obfuscatedName.substring(0, lastIndex);
+        final String innerClassName = obfuscatedName.substring(lastIndex + 1);
+
+        // Get the parent class
+        return this.getClassMapping(parentClassName)
+                // Get and return the inner class
+                .map(parentClassMapping -> parentClassMapping.getOrCreateInnerClassMapping(innerClassName));
+    }
+
+    /**
      * Gets, or creates should it not exist, a class mapping, of the given
      * obfuscated name.
      *

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/AbstractClassMappingImpl.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/impl/model/AbstractClassMappingImpl.java
@@ -81,6 +81,16 @@ public abstract class AbstractClassMappingImpl<M extends ClassMapping>
 
     @Override
     public Optional<FieldMapping> getFieldMapping(final FieldSignature signature) {
+        return Optional.ofNullable(this.fields.get(signature));
+    }
+
+    @Override
+    public Optional<FieldMapping> getFieldMapping(final String obfuscatedName) {
+        return Optional.ofNullable(this.fieldsByName.get(obfuscatedName));
+    }
+
+    @Override
+    public Optional<FieldMapping> computeFieldMapping(FieldSignature signature) {
         // If the field type is not provided, lookup up only the field name
         if (!signature.getType().isPresent()) {
             return this.getFieldMapping(signature.getName());
@@ -93,11 +103,6 @@ public abstract class AbstractClassMappingImpl<M extends ClassMapping>
             return mapping != null ?
                     this.getMappings().getModelFactory().createFieldMapping(mapping.getParent(), sig, mapping.getDeobfuscatedName()) : null;
         }));
-    }
-
-    @Override
-    public Optional<FieldMapping> getFieldMapping(final String obfuscatedName) {
-        return Optional.ofNullable(this.fieldsByName.get(obfuscatedName));
     }
 
     @Override

--- a/lorenz/src/main/java/me/jamiemansfield/lorenz/model/ClassMapping.java
+++ b/lorenz/src/main/java/me/jamiemansfield/lorenz/model/ClassMapping.java
@@ -80,22 +80,54 @@ public interface ClassMapping<M extends ClassMapping> extends Mapping<M> {
      * Gets the field mapping of the given signature of the
      * class mapping, should it exist.
      *
+     * <p><strong>Note:</strong> The field signature is looked up as-is,
+     * so if the loaded mappings use field types, looking up a signature
+     * without type will fail. Consider using {@link #getFieldMapping(String)}
+     * or {@link #computeFieldMapping(FieldSignature)}.</p>
+     *
      * @param signature The signature of the field
      * @return The field mapping, wrapped in an {@link Optional}
      * @since 0.4.0
+     * @see #getFieldMapping(String)
+     * @see #computeFieldMapping(FieldSignature)
      */
     Optional<FieldMapping> getFieldMapping(final FieldSignature signature);
 
     /**
-     * Gets the field mapping of the given obfuscated name of the
-     * class mapping, should it exist.
+     * Gets a field mapping of the given obfuscated name of the
+     * class mapping, should it exist. If multiple fields mappings with
+     * the same name (but different types) exist, only one of them will
+     * be returned.
+     *
+     * <p><strong>Note:</strong> This is <strong>not</strong> equivalent
+     * to calling {@link #getFieldMapping(FieldSignature)} with a
+     * {@code null} field type. Use {@link #computeFieldMapping(FieldSignature)}
+     * to flexibly lookup field signatures with or without type.</p>
      *
      * @param obfuscatedName The obfuscated name of the field mapping
      * @return The field mapping, wrapped in an {@link Optional}
+     * @see #getFieldMapping(FieldSignature)
+     * @see #computeFieldMapping(FieldSignature)
      */
-    default Optional<FieldMapping> getFieldMapping(final String obfuscatedName) {
-        return this.getFieldMapping(new FieldSignature(obfuscatedName, (FieldType) null));
-    }
+    Optional<FieldMapping> getFieldMapping(final String obfuscatedName);
+
+    /**
+     * Attempts to locate a field mapping for the given obfuscated field
+     * signature. Unlike {@link #getFieldMapping(FieldSignature)} this method
+     * will attempt to match the field signature with or without type:
+     *
+     * <p>If {@link FieldSignature#getType()} is empty,
+     * {@link #getFieldMapping(String)} is returned.
+     * Otherwise, the signature is looked up with type. If that fails, the
+     * signature is looked up again without type. Note that it will insert
+     * a new {@link FieldMapping} with the specified type for caching purposes.</p>
+     *
+     * @param signature The (obfuscated) signature of the field
+     * @return The field mapping, wrapped in an {@link Optional}
+     * @see #getFieldMapping(FieldSignature)
+     * @see #getFieldMapping(String)
+     */
+    Optional<FieldMapping> computeFieldMapping(final FieldSignature signature);
 
     /**
      * Creates a new field mapping, attached to this class mapping, using


### PR DESCRIPTION
Add a `computeClassMapping` and `computeFieldMapping` method to simplify remapping. `computeClassMapping` is equivalent to `getClassMapping` except that it will insert a new `InnerClassMapping` if a mapping for the outer class exists. `computeFieldMapping` uses the changes introduced in #10, `getFieldMapping` is the old simple getter again.

The main reason for this is that it's kind of weird to have a getter insert a new mapping into the mapping set. The getters should be without side-effect, imo. On the other hand, having only the getters makes it annoying to properly write a remapper. So I guess we should just have both.

I've tried to explain the exact differences between the methods in the Javadocs.