### PR TITLE
Allow mappings to be removed from the model

### DIFF
--- a/lorenz/src/main/java/org/cadixdev/lorenz/MappingSet.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/MappingSet.java
@@ -33,6 +33,7 @@ import org.cadixdev.bombe.type.Type;
 import org.cadixdev.lorenz.impl.MappingSetModelFactoryImpl;
 import org.cadixdev.lorenz.merge.MappingSetMerger;
 import org.cadixdev.lorenz.model.ClassMapping;
+import org.cadixdev.lorenz.model.InnerClassMapping;
 import org.cadixdev.lorenz.model.TopLevelClassMapping;
 import org.cadixdev.lorenz.model.jar.CompositeFieldTypeProvider;
 import org.cadixdev.lorenz.model.jar.FieldTypeProvider;
@@ -191,6 +192,28 @@ public class MappingSet implements Reversible<MappingSet, MappingSet>, Iterable<
         return this.getClassMapping(parentClassName)
                 // Get and return the inner class
                 .flatMap(parentClassMapping -> parentClassMapping.getInnerClassMapping(innerClassName));
+    }
+
+    /**
+     * Remove the class mapping for the given obfuscated name.
+     *
+     * @param obfuscatedName The class name to remove.
+     */
+    public void removeClassMapping(final String obfuscatedName) {
+        this.getClassMapping(obfuscatedName).ifPresent(this::removeClassMapping);
+    }
+
+    /**
+     * Remove the given {@link ClassMapping}.
+     *
+     * @param mapping The mapping to remove.
+     */
+    public void removeClassMapping(final ClassMapping<?, ?> mapping) {
+        if (mapping instanceof InnerClassMapping) {
+            ((InnerClassMapping) mapping).getParent().removeInnerClassMapping(mapping);
+        } else {
+            this.topLevelClasses.values().remove(mapping);
+        }
     }
 
     /**

--- a/lorenz/src/main/java/org/cadixdev/lorenz/impl/model/AbstractClassMappingImpl.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/impl/model/AbstractClassMappingImpl.java
@@ -134,6 +134,26 @@ public abstract class AbstractClassMappingImpl<M extends ClassMapping<M, P>, P>
     }
 
     @Override
+    public void removeFieldMapping(final FieldSignature signature) {
+        final FieldMapping mapping = this.fields.remove(signature);
+        if (mapping != null) {
+            this.fieldsByName.values().remove(mapping);
+        }
+    }
+
+    @Override
+    public void removeFieldMapping(final FieldMapping mapping) {
+        this.fields.values().remove(mapping);
+        this.fieldsByName.values().remove(mapping);
+    }
+
+    @Override
+    public void removeFieldMapping(final String obfuscatedName) {
+        this.fields.keySet().removeIf(sig -> sig.getName().equals(obfuscatedName));
+        this.fieldsByName.remove(obfuscatedName);
+    }
+
+    @Override
     public Collection<MethodMapping> getMethodMappings() {
         return Collections.unmodifiableCollection(this.methods.values());
     }
@@ -157,6 +177,16 @@ public abstract class AbstractClassMappingImpl<M extends ClassMapping<M, P>, P>
     }
 
     @Override
+    public void removeMethodMapping(final MethodSignature signature) {
+        this.methods.remove(signature);
+    }
+
+    @Override
+    public void removeMethodMapping(final MethodMapping mapping) {
+        this.methods.values().remove(mapping);
+    }
+
+    @Override
     public Collection<InnerClassMapping> getInnerClassMappings() {
         return Collections.unmodifiableCollection(this.innerClasses.values());
     }
@@ -177,6 +207,16 @@ public abstract class AbstractClassMappingImpl<M extends ClassMapping<M, P>, P>
     @Override
     public boolean hasInnerClassMapping(final String obfuscatedName) {
         return this.innerClasses.containsKey(obfuscatedName);
+    }
+
+    @Override
+    public void removeInnerClassMapping(String obfuscatedName) {
+        this.innerClasses.remove(obfuscatedName);
+    }
+
+    @Override
+    public void removeInnerClassMapping(final ClassMapping<?, ?> mapping) {
+        this.innerClasses.values().remove(mapping);
     }
 
     @Override

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/ClassMapping.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/ClassMapping.java
@@ -276,6 +276,29 @@ public interface ClassMapping<M extends ClassMapping<M, P>, P> extends Mapping<M
     }
 
     /**
+     * Remove all field mappings where the obfuscated field signature of
+     * the mapping matches the given signature.
+     *
+     * @param signature The signature of the field mapping to remove.
+     */
+    void removeFieldMapping(final FieldSignature signature);
+
+    /**
+     * Remove the given {@link FieldMapping} from this class mapping.
+     *
+     * @param mapping The field mapping to remove.
+     */
+    void removeFieldMapping(final FieldMapping mapping);
+
+    /**
+     * Remove all field mappings where the obfuscated name of the mapping
+     * matches the given signature.
+     *
+     * @param obfuscatedName The name of the field mapping to remove.
+     */
+    void removeFieldMapping(final String obfuscatedName);
+
+    /**
      * Gets an immutable collection of all of the method mappings
      * of the class mapping.
      *
@@ -400,6 +423,21 @@ public interface ClassMapping<M extends ClassMapping<M, P>, P> extends Mapping<M
     boolean hasMethodMapping(final MethodSignature signature);
 
     /**
+     * Remove all method mappings where the obfuscated signature of the
+     * mapping matches the given signature.
+     *
+     * @param signature The method signature to remove.
+     */
+    void removeMethodMapping(final MethodSignature signature);
+
+    /**
+     * Remove the given {@link MethodMapping} from this class mapping.
+     *
+     * @param mapping The method mapping to remove.
+     */
+    void removeMethodMapping(final MethodMapping mapping);
+
+    /**
      * Gets an immutable collection of all of the inner class
      * mappings of the class mapping.
      *
@@ -460,6 +498,21 @@ public interface ClassMapping<M extends ClassMapping<M, P>, P> extends Mapping<M
      *         {@code false} otherwise
      */
     boolean hasInnerClassMapping(final String obfuscatedName);
+
+    /**
+     * Remove all inner class mappings where the obfuscated name of the
+     * mapping matches the given name.
+     *
+     * @param obfuscatedName The inner class name to remove.
+     */
+    void removeInnerClassMapping(final String obfuscatedName);
+
+    /**
+     * Remove the given inner {@link ClassMapping} from this class mapping.
+     *
+     * @param mapping The inner class mapping to remove.
+     */
+    void removeInnerClassMapping(final ClassMapping<?, ?> mapping);
 
     /**
      * Establishes whether the class mapping has a de-obfuscation mapping, or


### PR DESCRIPTION
As a data model Lorenz's primary use is to be mutated, so this restriction only acts to make Lorenz  worse to work with.