### PR TITLE
Display bad line in (X)SrgReader Errors

### DIFF
--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/SrgReader.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/SrgReader.java
@@ -135,7 +135,7 @@ public class SrgReader extends TextMappingsReader {
                 // For now, Lorenz will just silently ignore those mappings.
             }
             else {
-                throw new IllegalArgumentException("Found unrecognised key: `" + key + "`!");
+                throw new IllegalArgumentException("Failed to process line: `" + line + "`!");
             }
         }
 

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/xsrg/XSrgReader.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/xsrg/XSrgReader.java
@@ -138,7 +138,7 @@ public class XSrgReader extends TextMappingsReader {
                 // For now, Lorenz will just silently ignore those mappings.
             }
             else {
-                throw new IllegalArgumentException("Found unrecognised key: `" + key + "`!");
+                throw new IllegalArgumentException("Failed to process line: `" + line + "`!");
             }
         }
 


### PR DESCRIPTION
This changes `SrgReader` & `XSrgReader` to match `CSrgReader` & `TSrgReader` in what is printed out when a bad line is found. 